### PR TITLE
Update Makefile for use with manpage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ compile:
 install:
 	@echo "Installing cfetch..."
 	cp -v cfetch /usr/bin
+	MAN="$(shell manpath|tr ':' '\n'|grep usr|grep share|grep -v local)";cp -v cfetch.1 $$MAN/man1/
 	@echo "Installation finished!"
 
 
@@ -18,6 +19,7 @@ install:
 uninstall:
 	@echo "Uninstalling cfetch..."
 	rm -rf /usr/bin/cfetch
+	MAN="$(shell whereis cfetch|tr ' ' '\n'|grep man)";rm -rf $$MAN
 	@echo "Uninstalling finished!"
 
 


### PR DESCRIPTION
I would add something like this to install the manpage. However, I can't say that this will work on all systems as I can only test on Ubuntu.

It should work as it only relies on the folowing:
```bash
manpath
tr
grep
whereis
```
All of these commands should come with most distributions of linux.

>Note that other distros may have different manpath structures. On my system(s) this: ```manpath|tr ':' '\n'|grep usr|grep share|grep -v local``` will output the "tld" man path.