### PR TITLE
edit user, kernel and uptime functions to not use shell commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Compile cfetch
 compile:
 	@echo "Compiling cfetch..."
-	gcc cfetch.c -o cfetch -Wall
+	gcc cfetch.c -o cfetch -Wall -Wextra
 	@echo "Compilation finished!"
 
 


### PR DESCRIPTION
There are functions in C that allow us to get the current user, hostname, kernel info and uptime without using shell commands. You can also find the users current shell this way, but there's more work to remove the `*/bin/*` part of the string. 

If you intend to only support Linux, there's also ways to get the memory usage by including `<sys/sysinfo.h>`.